### PR TITLE
solution for Problems with Query-Object-Parameter and Zabbix2.4 and for issue #4

### DIFF
--- a/ZabbixAPI.cs
+++ b/ZabbixAPI.cs
@@ -200,7 +200,8 @@ namespace Zabbix
                 parms = new
                 {
                     output = "extend",
-                    select_hosts = "extend",
+                    //select_hosts = "extend",
+                    selectHosts = "extend",
                     monitored = "1",
                     only_true = "1",
                     sortfield = "lastchange",
@@ -215,7 +216,8 @@ namespace Zabbix
                 parms = new
                 {
                     output = "extend",
-                    select_hosts = "extend",
+                    //select_hosts = "extend",
+                    selectHosts = "extend",
                     monitored = "1",
                     only_true = "1",
                     sortfield = "lastchange",
@@ -503,7 +505,8 @@ namespace Zabbix
             Params = new
             {
                 output = "extend",
-                select_hosts = "extend",
+                //select_hosts = "extend",
+                selectHosts = "extend",
                 monitored = "1",
                 templated = "0",
                 only_true = "1",
@@ -651,7 +654,8 @@ namespace Zabbix
                 output = "extend",
                 sortfield = "clock",
                 sortorder = "ASC",
-                select_hosts = "shorten",
+                //select_hosts = "shorten",
+                selectHosts = "shorten",
                 select_triggers = "shorten",
                 limit = "1000"
 


### PR DESCRIPTION
1)
after Problems with authentication to Zabbix 2.4.1...

use Query-Object without Param "auth" for API-Calls with method apiinfo.version" || "user.login"

see: Zabbix Documentation 2.0
apiinfo.version
string apiinfo.version(array)

"This method is available to unauthenticated users and should be called without the auth parameter in the JSON-RPC request. Starting from Zabbix 2.4 the method will return an error if the auth parameter is given."

2)
Issue #4 missing host name:    on alerts the host field is null.
the Parameter "select_hosts" seems to have been renamed to "selectHosts"

change all parameter definitions from select_hosts to selectHosts

see: 
Zabbix Documentation 2.0
trigger.get
integer/array trigger.get(object parameters
